### PR TITLE
docs: recommend installing React 16.8

### DIFF
--- a/components/docs/docs.mdx
+++ b/components/docs/docs.mdx
@@ -2,16 +2,16 @@
 
 ### Setup
 
-First, you need to install **React v16.7 or higher**:
+First, you need to install **React v16.8 or higher**:
 
 ```bash
-npm install --save react@^16.7.0-alpha.0 react-dom@^16.7.0-alpha.0
+npm install --save react@^16.8.0 react-dom@^16.8.0
 ```
 
 Or with yarn:
 
 ```bash
-yarn add react@^16.7.0-alpha.0 react-dom@^16.7.0-alpha.0
+yarn add react@^16.8.0 react-dom@^16.8.0
 ```
 
 Now you can start writing `useState` and `useEffect` in your code. Here's a simple counter example:

--- a/components/home/features.js
+++ b/components/home/features.js
@@ -13,7 +13,7 @@ export default () => (
           <h3 className="f3 fw6">Easy-to-use</h3>
           <p>
             Setting up React Hooks is as simple as upgrading to{' '}
-            <strong>React v16.7</strong> and using the new methods like{' '}
+            <strong>React v16.8</strong> and using the new methods like{' '}
             <code>useState</code>.
           </p>
           <Button href="/docs">Try it out &rarr;</Button>


### PR DESCRIPTION
The [official React Hooks documentation](https://reactjs.org/docs/hooks-intro.html) suggests installing the stable version of React >= 16.8.0 when using hooks, so this PR mirrors that and suggests installing 16.8.0 instead of 16.7.0-alpha.0.